### PR TITLE
Set memory limits.

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -18,6 +18,7 @@ services:
             - ${GRACC_HOST_PORT}:8080
         network_mode: bridge
         restart: always
+        mem_limit: 500M
     gracc-stash-raw:
         image: opensciencegrid/gracc-stash-raw:3.2
         env_file:
@@ -26,6 +27,7 @@ services:
             - AMQP_SSL=true
         network_mode: host
         restart: always
+        mem_limit: 1500M
     gracc-stash-summary:
         image: opensciencegrid/gracc-stash-summary:3.1
         env_file:
@@ -34,3 +36,4 @@ services:
             - AMQP_SSL=true
         network_mode: host
         restart: always
+        mem_limit: 1500M


### PR DESCRIPTION
Collector typically uses < 100M, 500M should be enough to handle
even several large updates simultaneously.

Logstash defaults to 1G max heap, so allow a bit extra for stack.