### PR TITLE
Update logstash 5.x/6.x to 6.8.21 and 7.x to 7.16.1

### DIFF
--- a/dev/logstash/Dockerfile
+++ b/dev/logstash/Dockerfile
@@ -1,3 +1,3 @@
-FROM logstash:5
+FROM docker.elastic.co/logstash/logstash:6.8.21
 COPY logstash.conf /gracc/
 CMD ["-f","/gracc/logstash.conf"]

--- a/gracc-stash-raw/Dockerfile
+++ b/gracc-stash-raw/Dockerfile
@@ -1,4 +1,4 @@
-FROM logstash:6.8.0
+FROM docker.elastic.co/logstash/logstash:6.8.21
 
 COPY logstash.conf /usr/share/logstash/pipeline/
 COPY gracc-raw-template.json /etc/gracc-stash/

--- a/gracc-stash-summary.transfer/Dockerfile
+++ b/gracc-stash-summary.transfer/Dockerfile
@@ -1,4 +1,4 @@
-FROM logstash:6.8.0
+FROM docker.elastic.co/logstash/logstash:6.8.21
 
 COPY logstash.conf /usr/share/logstash/pipeline/
 COPY gracc-summary-template.json /etc/gracc-stash/

--- a/gracc-stash-summary/Dockerfile
+++ b/gracc-stash-summary/Dockerfile
@@ -1,4 +1,4 @@
-FROM logstash:7.10.1
+FROM docker.elastic.co/logstash/logstash:7.16.1
 
 COPY logstash.conf /usr/share/logstash/pipeline/
 COPY gracc-summary-template.json /etc/gracc-stash/

--- a/prod/gracc-monitor/docker-compose.yaml
+++ b/prod/gracc-monitor/docker-compose.yaml
@@ -23,7 +23,7 @@ services:
             - 9113:9113
         network_mode: bridge
     logstash-cvmfs-sync-logs:
-       image: docker.elastic.co/logstash/logstash:5.5.1
+       image: docker.elastic.co/logstash/logstash:6.8.21
        volumes:
        - ./hcc-cvmfs-repo.logstash.conf:/usr/share/logstash/pipeline/logstash.conf
        - ./cilogon-osg.crt:/etc/cilogon-osg.crt

--- a/prod/gracc.osg/docker-compose.yml
+++ b/prod/gracc.osg/docker-compose.yml
@@ -48,7 +48,7 @@ services:
         restart: always
         network_mode: host
     logstash-glidein:
-        image: docker.elastic.co/logstash/logstash:5.5.1
+        image: docker.elastic.co/logstash/logstash:6.8.21
         volumes:
         - ./glidein-logs-logstash.conf:/usr/share/logstash/pipeline/glidein-logs-logstash.conf
         - /etc/grid-security/gracc.opensciencegrid.org-cert.pem:/etc/gracc.opensciencegrid.org-cert.pem


### PR DESCRIPTION
Bump logstash versions forward. Note that these changes are untested.